### PR TITLE
Run html2pdf as a non-privileged user

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,7 +32,7 @@ ADD app.py gunicorn.conf.py ./
 
 EXPOSE 80
 
-RUN nobody
+USER nobody
 
 ENTRYPOINT ["usr/local/bin/gunicorn"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -30,7 +30,7 @@ ENV PYTHONUNBUFFERED=1 PYTHONHASHSEED=random
 
 ADD app.py gunicorn.conf.py ./
 
-EXPOSE 80
+EXPOSE 8080
 
 USER nobody
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,8 @@ ADD app.py gunicorn.conf.py ./
 
 EXPOSE 80
 
+RUN nobody
+
 ENTRYPOINT ["usr/local/bin/gunicorn"]
 
 # Show the extended help

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ dependencies:
   override:
     - pip install requests
     - docker build -t html2pdf:latest .
-    - docker run -d -it -p 12345:80 html2pdf
+    - docker run -it -p 12345:80 html2pdf
     - sleep 10
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ dependencies:
   override:
     - pip install requests
     - docker build -t html2pdf:latest .
-    - docker run -it -p 12345:8080 html2pdf
+    - docker run -d -it -p 12345:8080 html2pdf
     - sleep 10
 
 test:

--- a/circle.yml
+++ b/circle.yml
@@ -6,7 +6,7 @@ dependencies:
   override:
     - pip install requests
     - docker build -t html2pdf:latest .
-    - docker run -it -p 12345:80 html2pdf
+    - docker run -it -p 12345:8080 html2pdf
     - sleep 10
 
 test:

--- a/gunicorn.conf.py
+++ b/gunicorn.conf.py
@@ -1,7 +1,7 @@
 # Gunicorn Configuration File.
 # See: http://docs.gunicorn.org/en/latest/settings.html
 
-bind = '0.0.0.0:80'
+bind = '0.0.0.0:8080'
 
 # Send error logs to stderr
 errorlog = '-'


### PR DESCRIPTION
Run as `nobody` for reduced host privileges for the application.

Side effect: We may to migrate to port `8080`.